### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/create-new-pre-release.yml
+++ b/.github/workflows/create-new-pre-release.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+  pre-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
           echo VERSION=$(cat VERSION).$GITHUB_RUN_NUMBER >> $GITHUB_ENV
 
       - name: Create GitHub pre-release
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
+        uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: v${{ env.VERSION }}

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -16,12 +16,12 @@ permissions:
 jobs:
   update_tag:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
-    environment:
       name: releaseNewActionVersion
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
         id: update-major-tag
-        uses: actions/publish-action@v0.1.0
+        uses: actions/publish-action@v0.2.0
         with:
           source-tag: ${{ env.TAG_NAME }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Ensure we are running the latest version of the mentioned actions. 

Add `SLACK_WEBHOOK` variable so we can notify via Slack.
Update versions to `latest` and `0.2.0` since those are the most up to date releases of those actions.
Change `build` job to `pre-release` since it matches what the workflow is doing.