### PR TITLE
fix: add missing environment field

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   update_tag:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
       name: releaseNewActionVersion
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`environment` was missing from the workflow file.  This fixes it.